### PR TITLE
fix: correct Excalidraw rendering and local workflow

### DIFF
--- a/local-run.sh
+++ b/local-run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Check for python-is-python3 installed
 if ! command -v python &>/dev/null; then
 	echo "It appears you do not have python-is-python3 installed"
@@ -43,7 +45,10 @@ if [[ -z "${VAULT}" ]]; then
 fi
 
 # Pull environment variables from the vault's netlify.toml when building (by generating env.sh to be sourced)
+rm -f env.sh
 python env.py
+source env.sh
+rm env.sh
 
 # Set the site and repo url as local since locally built
 export SITE_URL=local
@@ -65,7 +70,7 @@ else
 fi
 
 # Run conversion script
-source env.sh && python convert.py && rm env.sh
+python convert.py
 
 # Serve Zola site
 zola --root=build serve

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,11 @@
 
 shopt -s extglob
 
+if [[ ! -d __site/zola || ! -f __site/convert.py ]]; then
+	echo "run.sh is only for the deployment workspace. Use ./local-run.sh from this repository."
+	exit 1
+fi
+
 mkdir __obsidian
 mv !(__obsidian|__site) __obsidian 
 

--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,6 @@ import re
 import shutil
 from dataclasses import dataclass
 from datetime import datetime
-from distutils.util import strtobool
 from fnmatch import fnmatch
 from os import environ
 from pathlib import Path
@@ -302,7 +301,15 @@ class Settings:
     def is_true(cls, key: str) -> bool:
         """Returns whether an option's string value is true."""
         val = cls.options[key]
-        return bool(strtobool(val)) if val else False
+        if not val:
+            return False
+
+        normalized = val.lower()
+        if normalized in {"y", "yes", "t", "true", "on", "1"}:
+            return True
+        if normalized in {"n", "no", "f", "false", "off", "0"}:
+            return False
+        raise ValueError(f"invalid truth value {val!r}")
 
     @classmethod
     def _matches_patterns(cls, rel_path: Path, key: str) -> bool:

--- a/zola/static/js/main.js
+++ b/zola/static/js/main.js
@@ -9,7 +9,7 @@ document.getElementById("mode").addEventListener("click", () => {
     localStorage.setItem("theme", isDark() ? "dark" : "light");
 
     // Update graph colors if exists
-    if (graph) {
+    if (typeof graph !== "undefined" && typeof graph.setOptions === "function") {
         graph.setOptions({
             nodes: {
                 color: isDark() ? "#555" : "#d4d4d4",

--- a/zola/templates/docs/page.html
+++ b/zola/templates/docs/page.html
@@ -62,7 +62,7 @@
 {% if page.extra.is_excalidraw == "True" %}
 <script src="{{ get_url(path="js/excalidraw-canvas.js") | safe }}"></script>
 <script type="module">
-  import {exportToSvg} from "https://cdn.jsdelivr.net/npm/@excalidraw/excalidraw@0.18.0/+esm";
+  import {exportToSvg} from "https://cdn.jsdelivr.net/npm/@excalidraw/excalidraw@0.18.1/+esm";
 
   const compressedData = "{{ page.extra.excalidraw_data | safe }}".split("||||")
 
@@ -79,6 +79,7 @@
 
   // Track active canvas instances for cleanup on re-render
   const canvasInstances = [];
+  let renderVersion = 0;
 
   function getAppState(data, isDark) {
     return isDark
@@ -98,7 +99,73 @@
         };
   }
 
+  function namespaceSvgIds(svg, prefix) {
+    const idMap = new Map();
+    svg.querySelectorAll("[id]").forEach(element => {
+      const oldId = element.id;
+      const newId = `${prefix}-${oldId}`;
+      idMap.set(oldId, newId);
+      element.id = newId;
+    });
+
+    svg.querySelectorAll("*").forEach(element => {
+      Array.from(element.attributes).forEach(attribute => {
+        let value = attribute.value.replace(/url\(#([^)]+)\)/g, (match, id) => {
+          return idMap.has(id) ? `url(#${idMap.get(id)})` : match;
+        });
+        if (value.startsWith("#") && idMap.has(value.slice(1))) {
+          value = `#${idMap.get(value.slice(1))}`;
+        }
+        if (value !== attribute.value) {
+          element.setAttribute(attribute.name, value);
+        }
+      });
+    });
+  }
+
+  function fixArrowLabelMasks(svg) {
+    svg.querySelectorAll("mask").forEach(mask => {
+      const visibleRect = mask.querySelector('rect[fill="#fff"]');
+      const labelRect = mask.querySelector('rect[fill="#000"]');
+      if (!visibleRect || !labelRect) return;
+
+      const visibleWidth = Number(visibleRect.getAttribute("width"));
+      const visibleHeight = Number(visibleRect.getAttribute("height"));
+      const labelX = Number(labelRect.getAttribute("x"));
+      const labelY = Number(labelRect.getAttribute("y"));
+      const labelWidth = Number(labelRect.getAttribute("width"));
+      const labelHeight = Number(labelRect.getAttribute("height"));
+      const clipId = `clip-${mask.id}`;
+      const svgNamespace = "http://www.w3.org/2000/svg";
+
+      const clipPath = document.createElementNS(svgNamespace, "clipPath");
+      clipPath.id = clipId;
+      clipPath.setAttribute("clipPathUnits", "userSpaceOnUse");
+
+      const path = document.createElementNS(svgNamespace, "path");
+      path.setAttribute(
+        "d",
+        `M 0 0 H ${visibleWidth} V ${visibleHeight} H 0 Z ` +
+          `M ${labelX} ${labelY} H ${labelX + labelWidth} ` +
+          `V ${labelY + labelHeight} H ${labelX} Z`
+      );
+      path.setAttribute("clip-rule", "evenodd");
+      path.setAttribute("fill-rule", "evenodd");
+      clipPath.appendChild(path);
+
+      const maskReference = `url(#${mask.id})`;
+      svg.querySelectorAll("g[mask]").forEach(group => {
+        if (group.getAttribute("mask") !== maskReference) return;
+        group.removeAttribute("mask");
+        group.setAttribute("clip-path", `url(#${clipId})`);
+      });
+      mask.replaceWith(clipPath);
+    });
+  }
+
   async function renderAll() {
+    const currentRenderVersion = ++renderVersion;
+
     // Save current view state before destroying
     const savedStates = canvasInstances.map(c => c.getState());
 
@@ -106,10 +173,10 @@
     canvasInstances.forEach(c => c.destroy());
     canvasInstances.length = 0;
 
-    const elements = document.querySelectorAll(".excalidraw-preview");
+    const elements = Array.from(document.querySelectorAll(".excalidraw-preview"));
     const isDark = document.body.classList.contains("dark");
 
-    elements.forEach(async (element, i) => {
+    await Promise.all(elements.map(async (element, i) => {
       if (!parsedData[i]) return;
       try {
         // Clear previous content (keep loading spinner markup)
@@ -122,6 +189,10 @@
           files: parsedData[i].files || {},
           getDimensions: (width, height) => ({ width: width + 50, height: height + 50 })
         });
+        namespaceSvgIds(svg, `excalidraw-${currentRenderVersion}-${i}`);
+        fixArrowLabelMasks(svg);
+
+        if (currentRenderVersion !== renderVersion) return;
 
         const loading = element.querySelector('#loading');
         if (loading) loading.style.display = 'none';
@@ -130,14 +201,16 @@
         if (savedStates[i]) {
           canvas.restoreState(savedStates[i]);
         }
-        canvasInstances.push(canvas);
+        canvasInstances[i] = canvas;
 
       } catch (err) {
+        if (currentRenderVersion !== renderVersion) return;
+
         const loading = element.querySelector('#loading');
         if (loading) loading.innerHTML = `<span style="color:red">Error: ${err.message}</span>`;
         console.error(err);
       }
-    });
+    }));
   }
 
   // Initial render


### PR DESCRIPTION
## Summary

- namespace SVG resource IDs so multiple Excalidraw diagrams do not reuse masks
- replace broken arrow-label SVG masks with clip paths and preserve canvas state across theme changes
- update Excalidraw to 0.18.1
- support Python 3.12 local builds and stop immediately when conversion fails
- prevent deployment-only `run.sh` from relocating a development checkout
- avoid theme-toggle errors when no graph instance exists

## Validation

- rendered the affected Dropbox diagrams locally in Chromium in light and dark themes
- confirmed connector lines resume after labels and reach destination elements
- confirmed all embedded SVG IDs are unique
- confirmed canvas transforms remain stable across repeated theme toggles
- confirmed light theme persists across refresh
- confirmed the local Dropbox page returns HTTP 200