### PR TITLE
fix(callouts): support custom Obsidian titles

### DIFF
--- a/zola/sass/_custom.scss
+++ b/zola/sass/_custom.scss
@@ -335,7 +335,6 @@ li.nav-item {
 
 .callout-title {
   font-weight: 600;
-  text-transform: uppercase;
   font-size: 0.8rem;
   letter-spacing: 0.05em;
   margin-bottom: 0.5rem;

--- a/zola/static/js/main.js
+++ b/zola/static/js/main.js
@@ -27,16 +27,33 @@ document.getElementById("mode").addEventListener("click", () => {
 
 function updateCallOut(scope) {
     scope.querySelectorAll('blockquote').forEach(bq => {
-    const content = bq.innerHTML.trim();
-    
-    const match = content.match(/^(?:<p>)?\[!(\w+)\]/i);
+        const firstParagraph = bq.firstElementChild;
+        const marker = firstParagraph?.firstChild;
+        if (firstParagraph?.tagName !== 'P' || marker?.nodeType !== Node.TEXT_NODE) {
+            return;
+        }
 
-    if (match) {
+        const match = marker.textContent.match(/^\s*\[!([\w-]+)\][+-]?\s*(.*)$/i);
+        if (!match) {
+            return;
+        }
+
         const type = match[1].toLowerCase();
+        const title = match[2].trim() || type.charAt(0).toUpperCase() + type.slice(1);
+        const titleElement = document.createElement('div');
+        titleElement.className = 'callout-title';
+        titleElement.textContent = title;
+
+        marker.remove();
+        if (firstParagraph.firstElementChild?.tagName === 'BR') {
+            firstParagraph.firstElementChild.remove();
+        }
+        if (!firstParagraph.textContent.trim() && !firstParagraph.children.length) {
+            firstParagraph.remove();
+        }
+
         bq.classList.add('callout', `callout-${type}`);
-        bq.innerHTML = content.replace(/^(?:<p>)?\[!(\w+)\](?:<br>)?/, 
-        `<div class="callout-title">${type}</div><p>`);
-    }
+        bq.prepend(titleElement);
     });
 }
 


### PR DESCRIPTION
## Summary
- parse Obsidian callout markers from the generated blockquote DOM
- preserve custom same-line titles and body markup
- retain title casing while keeping fallback titles for untitled callouts

## Validation
- `node --check zola/static/js/main.js`
- full local vault export and Zola build